### PR TITLE
syntax: fix invalid parsing with square brackets in desc

### DIFF
--- a/syntax/xit.vim
+++ b/syntax/xit.vim
@@ -75,25 +75,25 @@ hi! link xitInvalid xInvalid
 syn match xitCheckboxOpen "\v^\[ \]" nextgroup=xitCheckboxOpenSpace
 syn match xitCheckboxOpenSpace " " nextgroup=xitCheckboxOpenPriority contained
 syn match xitCheckboxOpenPriority "\v(\.*!*)" nextgroup=xitCheckboxOpenDesc contained
-syn region xitCheckboxOpenDesc start="." end=/\v(\[|^[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
+syn region xitCheckboxOpenDesc start="." end=/\v(^[\[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
 
 " Matches a checkbox like "[x]"
 syn match xitCheckboxChecked "\v^\[x\]" nextgroup=xitCheckboxCheckedSpace
 syn match xitCheckboxCheckedSpace " " nextgroup=xitCheckboxCheckedPriority contained
 syn match xitCheckboxCheckedPriority "\v( *\.*!*)" nextgroup=xitCheckboxCheckedDesc contained
-syn region xitCheckboxCheckedDesc start="." end=/\v(\[|^[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
+syn region xitCheckboxCheckedDesc start="." end=/\v(^[\[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
 
 " Matches a checkbox like "[@]"
 syn match xitCheckboxOngoing "\v^\[\@\]" nextgroup=xitCheckboxOngoingSpace
 syn match xitCheckboxOngoingSpace " " nextgroup=xitCheckboxOngoingPriority contained
 syn match xitCheckboxOngoingPriority "\v(\.*!*)" nextgroup=xitCheckboxOngoingDesc contained
-syn region xitCheckboxOngoingDesc start="." end=/\v(\[|^[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
+syn region xitCheckboxOngoingDesc start="." end=/\v(^[\[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
 
 " This matches a checkbox like "[~]"
 syn match xitCheckboxObsolete "\v^\[\~\]" nextgroup=xitCheckboxObsoleteSpace
 syn match xitCheckboxObsoleteSpace " " nextgroup=xitCheckboxObsoletePriority contained
 syn match xitCheckboxObsoletePriority "\v(\.*!*)" nextgroup=xitCheckboxObsoleteDesc contained
-syn region xitCheckboxObsoleteDesc start="." end=/\v(\[|^[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
+syn region xitCheckboxObsoleteDesc start="." end=/\v(^[\[a-zA-Z0-9])/me=e-1 contained contains=xitTag,xitDueDate
 
 " Matches a tag with letters, numbers, _, or -
 syn match xitTag "\v#[^ \r\:\?\.\!\(\)\,]+" nextgroup=xitValue contained
@@ -102,7 +102,7 @@ syn match xitTag "\v#[^ \r\:\?\.\!\(\)\,]+" nextgroup=xitValue contained
 syn match xitDueDate "\v-\> \d{4}([-\/]|)([WQ]\d{1,2}|\d{2}[-\/]\d{2}|\d{2})( |)" contained
 
 " Matches a invalid case
-syn match xitInvalid "\v\[([^x~@ ]\]| \][^ ]| {2,}\]|[x@~]{2,}|.{2,}\]).*"
+syn match xitInvalid "\v^\[([x~@ ]\])@!([^x~@ ]\]| \][^ ]|.{2,}\]).*"
 
 
 " Invalid empty checkboxes


### PR DESCRIPTION
Make xitCheckbox*Desc end with either "[" or title *immediately* after the start of a line, instead of ending whenever it finds a "[".

Use negative lookahead in xitInvalid regex so that a line with a valid checkbox that consists of `\[[x~@ ]\]` is immediately treated as valid. Also only check for the checkbox at the start of the line, so characters enclosed by square brackets in the middle of a description don't get considered invalid.

Test data:
```
[ ] Hello [ -> 2022-12
Test
[~] Bye (a[b]) -> 2023-01
[@] Bye (a[b]) -> 2023-01
[x] Bye (a[b]) -> 2023-01

Test data
[~] a]
[x] a
[~] a
[@] a
[ ] a
[ a] a
[ x ] a
[@x] a
[  ] a
```

Before this patch, lines 3-5 and line 8 are incorrectly marked as invalid, and the due date on the first line isn't highlighted.

With this patch, the lines incorrectly marked as invalid are no longer marked as invalid. The last 4 lines, which are actually invalid, remain marked as invalid. The due dates are now highlighted.
